### PR TITLE
Update uuid to version 3.0.0

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,7 +12,7 @@ works with [MicroMinion platform](https://github.com/MicroMinion/mm-platform)
 var MicroMinionPlatform = require('mm-platform')
 var TenantService = require('mm-services-tenant')
 var Runtime = require('mm-box')
-var uuid = require('node-uuid')
+var uuid = require('uuid')
 var MemStore = require('kad-memstore')
 
 var platform = new MicroMinionPlatform()

--- a/index.js
+++ b/index.js
@@ -3,7 +3,7 @@
 var assert = require('assert')
 var _ = require('lodash')
 var identityHelpers = require('mm-create-identity')
-var uuid = require('node-uuid')
+var uuid = require('uuid')
 var winstonWrapper = require('winston-meta-wrapper')
 
 var TenantService = function (options) {

--- a/package.json
+++ b/package.json
@@ -39,7 +39,7 @@
   "dependencies": {
     "lodash": "4.14.2",
     "mm-create-identity": "1.2.2",
-    "node-uuid": "1.4.7",
+    "uuid": "^3.0.0",
     "winston-meta-wrapper": "1.2.0"
   }
 }


### PR DESCRIPTION
## Version 3.0.0 of [uuid](https://github.com/kelektiv/node-uuid) just got published.

Hi there,

This week a new version of the [uuid](https://github.com/kelektiv/node-uuid) module got released. The old module which was available by the name [node-uuid](https://www.npmjs.com/package/node-uuid) got deprecated and will show error message upon every install of the module.

To get rid of those install errors I've created this **automated pull request**. I've run some checks against your code base to test whether you're using one of the [deprecated apis](https://github.com/kelektiv/node-uuid/commit/5ae7287fc935eb55ef39133e4be17ef623ca000e), but this isn't the case.


Please test the changes against your code. I didn't run any tests and therefore can't guarantee that it isn't breaking. You can also just close this pr if you don't want to update your module.

In case there's already another pr open to upgrade uuid, I'm sorry for the effort I'm causing.